### PR TITLE
お気に入りのシーン保存ボタン作成

### DIFF
--- a/workspaces/index.html
+++ b/workspaces/index.html
@@ -37,6 +37,7 @@
   <script src="modules/videojs-hls-quality-selector/videojs-hls-quality-selector.js"></script>
   <script src="modules/videojs-vtt-thumbnails/videojs-vtt-thumbnails.js"></script>
   <script src="myModules/skipTime.js"></script>
+  <script src="myModules/favoriteTime.js"></script>
   <script src="index.js"></script>
 
 </body>

--- a/workspaces/index.html
+++ b/workspaces/index.html
@@ -3,6 +3,8 @@
 
 <head>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link href="https://vjs.zencdn.net/7.20.1/video-js.css" rel="stylesheet" />
+  <link href="modules/videojs-vtt-thumbnails/videojs-vtt-thumbnails.css" rel="stylesheet" />
   <meta charset="UTF-8">
 </head>
 
@@ -16,11 +18,26 @@
     </nav>
   </header>
   <main class="container-sm my-3">
+    <div>
       <h1>Video Player</h1>
+      <video id="my-video" class="video-js vjs-default-skin vjs-big-play-centered">
+        <p>動画を再生するにはvideoタグをサポートしたブラウザが必要です。</p>
+      </video>
+      <div>
+        <p>Playback time: <span id="currentTime">0</span> sec</p>
+      </div>
+      </div>
   </main>
   <footer class="text-center bg-dark text-light mt-auto">
     ©2022 <a class="text-reset" target="_blank" href="https://eviry.com">COPYRIGHT © EVIRY INC. ALL RIGHT RESERVED.</a>
   </footer>
+
+  <script src="https://vjs.zencdn.net/7.20.1/video.min.js"></script>
+  <script src="modules/videojs-contrib-quality-levels/videojs-contrib-quality-levels.js"></script>
+  <script src="modules/videojs-hls-quality-selector/videojs-hls-quality-selector.js"></script>
+  <script src="modules/videojs-vtt-thumbnails/videojs-vtt-thumbnails.js"></script>
+  <script src="myModules/skipTime.js"></script>
+  <script src="index.js"></script>
 
 </body>
 

--- a/workspaces/index.js
+++ b/workspaces/index.js
@@ -57,6 +57,9 @@ player.hlsQualitySelector({
 // skipボタンを有効にする
 player.skipTime(true);
 
+// 自主制作機能を有効にする
+player.favoriteTime(true);
+
 // シークバーにマウスを乗せたときにサムネイルを表示する
 player.vttThumbnails({
   src: "thumbnails/big_buck_bunny_thumbnails.vtt",

--- a/workspaces/index.js
+++ b/workspaces/index.js
@@ -48,3 +48,32 @@ const player = videojs("my-video", {
     },
   ],
 });
+
+// 画質選択の設定を有効にする
+player.hlsQualitySelector({
+  displayCurrentQuality: true,
+});
+
+// skipボタンを有効にする
+player.skipTime(true);
+
+// シークバーにマウスを乗せたときにサムネイルを表示する
+player.vttThumbnails({
+  src: "thumbnails/big_buck_bunny_thumbnails.vtt",
+});
+
+// 再生時間が更新されるたびに実行される関数を設定する
+player.on("timeupdate", function () {
+  const span = document.getElementById("currentTime");
+  span.innerText = player.currentTime();
+});
+
+const play = () => player.play();
+
+const pause = () => player.pause();
+
+const mute = () => player.muted(true);
+
+const unMute = () => player.muted(false);
+
+const playback = (x) => player.playbackRate(x);

--- a/workspaces/myModules/favoriteTime.js
+++ b/workspaces/myModules/favoriteTime.js
@@ -1,0 +1,52 @@
+/*
+【説明】
+お気に入りのシーンが流れる時間を保存しておき、いつでもその時間に飛べる機能を作りました
+コントロールバー上にある星の記号を押すと、その時の動画の再生時間を保存します
+星の横に、保存した時間が文字で表示されます
+文字を押すとその時間に飛べます
+*/
+
+const favoriteTime = (bool) => {
+  var sec = null;
+  
+  // コントロールバーの要素を取得
+  const controlBar = document.querySelector(".vjs-control-bar");
+
+  // ボリュームパネルの要素を取得
+  const playbackRate = controlBar.querySelector(".vjs-playback-rate");
+
+
+  //ボタンを作成
+  const createButton = (icon) => {
+    const button = document.createElement("button");
+    button.className = "vjs-favorite-button";
+    button.innerHTML = icon;
+    button.style.fontSize = "1.8em";
+    return button;
+  };
+
+  const favoriteRegisterButton = createButton("&#9733;");
+  controlBar.insertBefore(favoriteRegisterButton, playbackRate);
+
+  const favoriteJumpButton = createButton(" ");
+  controlBar.insertBefore(favoriteJumpButton, playbackRate);
+
+
+  //星をクリックすると時間を保存  
+  favoriteRegisterButton.onclick = () => {
+    sec = player.currentTime();
+    favoriteJumpButton.innerHTML = Math.floor(sec/60).toString().padStart(2,"0") + ":" + Math.floor(sec%60).toString().padStart(2,"0");
+  }
+
+
+  //時間をクリックするとその時間に飛ぶ
+  favoriteJumpButton.onclick = () => {
+    if(sec != null){
+      player.currentTime(sec);
+    }
+  }
+
+}
+
+// videojsのイベントを追加する
+videojs.registerPlugin("favoriteTime", favoriteTime);


### PR DESCRIPTION
## 概要

お気に入りのシーンが流れる時間を保存しておき、いつでもその時間に飛べる機能を作りました。

コントロールバー上にある星の記号を押すと、その時の動画の再生時間を保存します
星の横に、保存した時間が文字で表示されます
文字を押すとその時間に飛べます

## 技術的変更概要

## 影響範囲

- video.jsプレイヤー周り

## このプルリクエストではやらないこと

- 別のプルリクエストで対応する事があれば記載(無い場合は無しと記載)

## チェックリスト(全て ×/-になってからプルリクエストを作成すること)

`× : 実施済み / - : 対象外`

- [ ] lint を実施した、実施していない場合その理由を記載 (理由:
- [ ] テストを実装・修正した。
- [X] 動作確認（ローカル環境）を実施した、実施していない場合その理由を記載 (理由:
- [ ] 動作確認（開発環境）を実施した、実施していない場合その理由を記載 (理由:
- [ ] 非機能要件（パフォーマンス、バッチ実行時間、サーバー負荷など）について問題ないことを確認した。

## スクリーンショット
### 未選択時
![スクリーンショット 2023-02-09 21 14 04](https://user-images.githubusercontent.com/42641673/217810557-8b865ef9-99b7-431f-89fc-78211c9a875b.png)

### 選択時
![スクリーンショット 2023-02-09 21 15 28](https://user-images.githubusercontent.com/42641673/217810579-50ea1d37-c0ce-4b35-9290-b3f7d454865d.png)
